### PR TITLE
Revert "fixed typo" revert to "Railway Oriented Programming"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ResultBoxes
 
-C# Results Library that focus on Railroad Oriented Programming.
+C# Results Library that focus on Railway Oriented Programming.
 
 # How can you install?
 
@@ -29,9 +29,9 @@ There is of course pros and cons of result type.
 - C# is not pure functional language.
 - It seems complex for someone not used to the functional programming.
 
-This ResultBoxes try to be simple Result type, that fully use lately introduced pattern matching feature. And first class support of the `Railroad Oriented Programming` that introduced with Scott Wlaschin with following article.
+This ResultBoxes try to be simple Result type, that fully use lately introduced pattern matching feature. And first class support of the `Railway Oriented Programming` that introduced with Scott Wlaschin with following article.
 
-[Railroad Oriented Programming](https://fsharpforfunandprofit.com/rop/)
+[Railway Oriented Programming](https://fsharpforfunandprofit.com/rop/)
 
 # Usage
 
@@ -39,10 +39,10 @@ This ResultBoxes try to be simple Result type, that fully use lately introduced 
 2. Don't use nullable value as Type of the Value
 3. Wrapping throwing function that returns value.
 4. Wrapping void function.
-5. Railroad Oriented Programming - Method Chain
-6. Railroad Oriented Programming - Async Task Functions.
-7. Railroad Oriented Programming - Combine Value
-8. Railroad Oriented Programming with Wrapping Function with Try.
+5. Railway Oriented Programming - Method Chain
+6. Railway Oriented Programming - Async Task Functions.
+7. Railway Oriented Programming - Combine Value
+8. Railway Oriented Programming with Wrapping Function with Try.
 
 ## 1. Simple Function and Use Result Function
 
@@ -228,9 +228,9 @@ internal class Program
 }
 ```
 
-## 5. Railroad Oriented Programming - Method Chain
+## 5. Railway Oriented Programming - Method Chain
 
-Railroad Oriented Programming (ROP) is a functional programming pattern that facilitates error handling and is often used in languages that support functional programming concepts, like F#, Haskell, and others. The analogy of a Railroad is used to describe the flow of data through a series of functions, similar to how a train travels along tracks.
+Railway Oriented Programming (ROP) is a functional programming pattern that facilitates error handling and is often used in languages that support functional programming concepts, like F#, Haskell, and others. The analogy of a railway is used to describe the flow of data through a series of functions, similar to how a train travels along tracks.
 
 ResultBoxes supports ROP by providing chain method to connect functions and simply write error handling code.
 
@@ -291,7 +291,7 @@ internal class Program
 }
 ```
 
-## 6. Railroad Oriented Programming - Async Task Functions.
+## 6. Railway Oriented Programming - Async Task Functions.
 
 Async method returns `Task<ResultBox<TValue>>`, but we provide async chaining methods as well.
 
@@ -423,9 +423,9 @@ internal class Program
 }
 ```
 
-## 7. Railroad Oriented Programming - Combine Value
+## 7. Railway Oriented Programming - Combine Value
 
-We have cases that need to prepare 2 or more value and pass it to next function. One way to achieve this is, programmer make a wrapping function and gather two value in function and use Railroad to handle results. But ResultBoxes provide `CombineValue` methods, which follows first Result, run second function and instead of passing only last executed value, but both first value and second value together and pass it to third function.
+We have cases that need to prepare 2 or more value and pass it to next function. One way to achieve this is, programmer make a wrapping function and gather two value in function and use railway to handle results. But ResultBoxes provide `CombineValue` methods, which follows first Result, run second function and instead of passing only last executed value, but both first value and second value together and pass it to third function.
 
 ![CombineValue](./docs/images/CombineValue.png)
 
@@ -494,12 +494,12 @@ internal class Program
 }
 ```
 
-We can use `Conveyor` and `CombineValue` Method in Async as well.
+We can use `RailWay` and `CombineValue` Method in Async as well.
 
-## 8. Railroad Oriented Programming with Wrapping Function with Try.
+## 8. Railway Oriented Programming with Wrapping Function with Try.
 
 Example above in **3. Wrapping throwing function that returns value.
-** can be use in the Railroad Oriented Method Chain as well.
+** can be use in the Railway Oriented Method Chain as well.
 
 ```csharp
 internal class Program

--- a/src/ResultBoxes/ResultBoxes.Test/UnitTest1.cs
+++ b/src/ResultBoxes/ResultBoxes.Test/UnitTest1.cs
@@ -10,93 +10,93 @@ public class UnitTest1
     }
 
     [Fact]
-    public async Task RailroadAsyncSpec()
+    public async Task RailwayAsyncSpec()
     {
-        var sut = await FunctionDeclarations.RailroadWithAsync(1);
+        var sut = await FunctionDeclarations.RailwayWithAsync(1);
 
         Assert.True(sut.IsSuccess);
         Assert.Equal(12, sut.GetValue());
     }
     [Fact]
-    public async Task Railroad2AsyncSpec()
+    public async Task Railway2AsyncSpec()
     {
-        var sut = await FunctionDeclarations.Railroad2Async(1);
+        var sut = await FunctionDeclarations.Railway2Async(1);
 
         Assert.True(sut.IsSuccess);
         Assert.Equal(12, sut.GetValue());
     }
     [Fact]
-    public void RailroadSpec()
+    public void RailwaySpec()
     {
-        var sut = FunctionDeclarations.RailroadInstance(1);
+        var sut = FunctionDeclarations.RailwayInstance(1);
 
         Assert.True(sut.IsSuccess);
         Assert.Equal(12, sut.GetValue());
     }
     [Fact]
-    public void RailroadInstance2Spec()
+    public void RailwayInstance2Spec()
     {
-        var sut = FunctionDeclarations.RailroadInstance2(1);
+        var sut = FunctionDeclarations.RailwayInstance2(1);
 
         Assert.True(sut.IsSuccess);
         Assert.Equal(12, sut.GetValue());
     }
     [Fact]
-    public void RailroadInstance2WithErrorSpec()
+    public void RailwayInstance2WithErrorSpec()
     {
-        var sut = FunctionDeclarations.RailroadInstance2(4);
+        var sut = FunctionDeclarations.RailwayInstance2(4);
 
         Assert.False(sut.IsSuccess);
         Assert.True(sut.Exception is ApplicationException);
     }
     [Fact]
-    public void RailroadInstance2WithError2Spec()
+    public void RailwayInstance2WithError2Spec()
     {
-        var sut = FunctionDeclarations.RailroadInstance2(3);
+        var sut = FunctionDeclarations.RailwayInstance2(3);
 
         Assert.False(sut.IsSuccess);
         Assert.True(sut.Exception is ApplicationException);
     }
 
     [Fact]
-    public void Railroad2Calc3Spec()
+    public void Railway2Calc3Spec()
     {
-        var sut = FunctionDeclarations.Railroad2Calc3(9, 2, 3);
+        var sut = FunctionDeclarations.Railway2Calc3(9, 2, 3);
         Assert.True(sut.IsSuccess);
         Assert.Equal(2, sut.GetValue());
     }
     [Fact]
-    public async Task Railroad2Calc3AsyncSpec()
+    public async Task Railway2Calc3AsyncSpec()
     {
-        var sut = await FunctionDeclarations.RailroadCalc3Async(9, 2, 3);
+        var sut = await FunctionDeclarations.RailwayCalc3Async(9, 2, 3);
         Assert.True(sut.IsSuccess);
         Assert.Equal(2, sut.GetValue());
     }
     [Fact]
-    public async Task RailroadCalc3Async2Spec()
+    public async Task RailwayCalc3Async2Spec()
     {
-        var sut = await FunctionDeclarations.RailroadCalc3Async2(9, 2, 3);
+        var sut = await FunctionDeclarations.RailwayCalc3Async2(9, 2, 3);
         Assert.True(sut.IsSuccess);
         Assert.Equal(2, sut.GetValue());
     }
     [Fact]
-    public void Railroad2Calc4Spec()
+    public void Railway2Calc4Spec()
     {
-        var sut = FunctionDeclarations.Railroad2Calc4(9, 2, 3);
+        var sut = FunctionDeclarations.Railway2Calc4(9, 2, 3);
         Assert.True(sut.IsSuccess);
         Assert.Equal(2, sut.GetValue());
     }
     [Fact]
-    public void Railroad2Calc4SpecThrowing()
+    public void Railway2Calc4SpecThrowing()
     {
-        var sut = FunctionDeclarations.Railroad2Calc4(9, 101, 3);
+        var sut = FunctionDeclarations.Railway2Calc4(9, 101, 3);
         Assert.False(sut.IsSuccess);
         Assert.True(sut.Exception is ApplicationException);
     }
     [Fact]
-    public async Task Railroad3AsyncSpec()
+    public async Task Railway3AsyncSpec()
     {
-        var sut = await FunctionDeclarations.Railroad3Async(1);
+        var sut = await FunctionDeclarations.Railway3Async(1);
         Assert.True(sut.IsSuccess);
         Assert.Equal(12, sut.GetValue());
     }

--- a/src/ResultBoxes/ResultBoxes.Usage/FunctionDeclarations.cs
+++ b/src/ResultBoxes/ResultBoxes.Usage/FunctionDeclarations.cs
@@ -111,16 +111,16 @@ public static class FunctionDeclarations
             }
         };
 
-    public static ResultBox<int> RailroadCalc3(int target1, int target2, int target3)
+    public static ResultBox<int> RailwayCalc3(int target1, int target2, int target3)
         => Increment(target1)
             .Conveyor(value1 => Add(value1, target2))
             .Conveyor(value2 => Divide(value2, target3));
-    public static ResultBox<int> Railroad2Calc3(int target1, int target2, int target3)
+    public static ResultBox<int> Railway2Calc3(int target1, int target2, int target3)
         => Increment(target1)
             .Combine(Add(target2, target3))
             .Conveyor(Divide);
 
-    public static ResultBox<int> Railroad2CalcG(int target1, int target2, int target3)
+    public static ResultBox<int> Railway2CalcG(int target1, int target2, int target3)
         => Increment(target1)
             .Combine(Add(target2, target3))
             .Conveyor(DivideConverter);
@@ -130,26 +130,26 @@ public static class FunctionDeclarations
     // .Conveyor((values) => Divide(values.Value1, values.Value2));
 
 
-    public static ResultBox<int> Railroad2Calc4(int target1, int target2, int target3)
+    public static ResultBox<int> Railway2Calc4(int target1, int target2, int target3)
         => Increment(target1)
             .CombineWrapTry(() => AddWithThrowing(target2, target3))
             .ConveyorWrapTry(DivideWithThrowing);
 
-    public static Task<ResultBox<int>> RailroadCalc3Async(
+    public static Task<ResultBox<int>> RailwayCalc3Async(
         int target1,
         int target2,
         int target3)
         => IncrementAsync(target1)
             .Combine(() => AddAsync(target2, target3))
             .Conveyor(DivideAsync);
-    public static Task<ResultBox<int>> RailroadCalc3Async2(
+    public static Task<ResultBox<int>> RailwayCalc3Async2(
         int target1,
         int target2,
         int target3)
         => Increment(target1)
             .Combine(() => AddAsync(target2, target3))
             .Conveyor(Divide);
-    public static Task<ResultBox<int>> RailroadCalc3Async4(
+    public static Task<ResultBox<int>> RailwayCalc3Async4(
         int target1,
         int target2,
         int target3)
@@ -157,11 +157,11 @@ public static class FunctionDeclarations
             .CombineWrapTry(() => AddAsyncWithThrowing(target2, target3))
             .ConveyorWrapTry(DivideAsyncWithThrowing);
 
-    public static ResultBox<int> RailroadCalc3Async3(int target1, int target2, int target3)
+    public static ResultBox<int> RailwayCalc3Async3(int target1, int target2, int target3)
         => Increment(target1)
             .Combine(Add(target2, target3))
             .ConveyorWrapTry(DivideWithThrowing);
-    public static Task<ResultBox<int>> RailroadCalc3Async5(
+    public static Task<ResultBox<int>> RailwayCalc3Async5(
         int target1,
         int target2,
         int target3)
@@ -169,14 +169,14 @@ public static class FunctionDeclarations
             .CombineWrapTry(() => AddAsyncWithThrowing(target2, target3))
             .Conveyor(DivideAsync);
 
-    public static Task<ResultBox<int>> Railroad2Calc3Async6(
+    public static Task<ResultBox<int>> Railway2Calc3Async6(
         int target1,
         int target2,
         int target3)
         => Increment(target1)
             .Combine(Add(target2, target3))
             .Conveyor(DivideAsync);
-    public static Task<ResultBox<int>> Railroad2Calc3Async7(
+    public static Task<ResultBox<int>> Railway2Calc3Async7(
         int target1,
         int target2,
         int target3)
@@ -184,22 +184,22 @@ public static class FunctionDeclarations
             .Combine(Add(target2, target3))
             .ConveyorWrapTry(DivideAsyncWithThrowing);
 
-    public static ResultBox<int> RailroadInstance(int target1)
+    public static ResultBox<int> RailwayInstance(int target1)
         => Increment(target1)
             .Conveyor(Double)
             .Conveyor(Triple);
-    public static ResultBox<int> RailroadInstance2(int target1)
+    public static ResultBox<int> RailwayInstance2(int target1)
         => ResultBox.WrapTry(() => IncrementWithThrowing(target1))
             .Conveyor(Double)
             .ConveyorWrapTry(TripleWithThrowing);
 
-    public static Task<ResultBox<int>> RailroadWithAsync(int target1)
+    public static Task<ResultBox<int>> RailwayWithAsync(int target1)
         => IncrementAsync(target1).Conveyor(DoubleAsync).Conveyor(TripleAsync);
-    public static Task<ResultBox<int>> Railroad2Async(int target1)
+    public static Task<ResultBox<int>> Railway2Async(int target1)
         => Increment(target1).Conveyor(DoubleAsync).Conveyor(TripleAsync);
-    public static Task<ResultBox<int>> Railroad3Async(int target1)
+    public static Task<ResultBox<int>> Railway3Async(int target1)
         => Increment(target1).Conveyor(DoubleAsync).Conveyor(Triple);
-    public static Task<ResultBox<int>> Railroad4Async(int target1)
+    public static Task<ResultBox<int>> Railway4Async(int target1)
         => ResultBox.WrapTry(() => IncrementAsyncWithThrowing(target1))
             .ConveyorWrapTry(DoubleAsyncWithThrowing)
             .Conveyor(TripleAsync);

--- a/src/ResultBoxes/ResultBoxes/ResultBoxes.csproj
+++ b/src/ResultBoxes/ResultBoxes/ResultBoxes.csproj
@@ -7,12 +7,12 @@
         <RootNamespace>ResultBoxes</RootNamespace>
         <LangVersion>preview</LangVersion>
         <PackageId>ResultBoxes</PackageId>
-        <Version>0.3.6</Version>
+        <Version>0.3.8</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>ResultBoxes - C# Results Library that focus on Railway Programming.</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/ResultBoxes</RepositoryUrl>
-        <PackageVersion>0.3.6</PackageVersion>
+        <PackageVersion>0.3.8</PackageVersion>
         <Description>Add ResultBox.FromValue()</Description>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/ResultBoxes/ResultBoxes/ResultBoxes.csproj
+++ b/src/ResultBoxes/ResultBoxes/ResultBoxes.csproj
@@ -7,12 +7,12 @@
         <RootNamespace>ResultBoxes</RootNamespace>
         <LangVersion>preview</LangVersion>
         <PackageId>ResultBoxes</PackageId>
-        <Version>0.3.7</Version>
+        <Version>0.3.6</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
-        <PackageDescription>ResultBoxes - C# Results Library that focus on Railroad Programming.</PackageDescription>
+        <PackageDescription>ResultBoxes - C# Results Library that focus on Railway Programming.</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/ResultBoxes</RepositoryUrl>
-        <PackageVersion>0.3.7</PackageVersion>
+        <PackageVersion>0.3.6</PackageVersion>
         <Description>Add ResultBox.FromValue()</Description>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
This reverts commit 924ff4d5c77bcd865a653b2c3b700de36ded9e6d.