### PR TITLE
"Add ResultBoxStartSpec test class"

### DIFF
--- a/src/ResultBoxes/ResultBoxes.Test/ResultBoxStartSpec.cs
+++ b/src/ResultBoxes/ResultBoxes.Test/ResultBoxStartSpec.cs
@@ -1,0 +1,21 @@
+namespace ResultBoxes.Test;
+
+public class ResultBoxStartSpec
+{
+    [Fact]
+    public void UseResultBoxStart()
+    {
+        var result = ResultBox.Start;
+        Assert.True(result.IsSuccess);
+    }
+    
+    [Fact]
+    public void UseResultBoxStart2()
+    {
+        var result = ResultBox.Start
+            .Conveyor(_ => ResultBox.Ok(1));
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, result.GetValue());
+    }
+
+}

--- a/src/ResultBoxes/ResultBoxes/ResultBox.cs
+++ b/src/ResultBoxes/ResultBoxes/ResultBox.cs
@@ -98,6 +98,8 @@ public record ResultBox<TValue> where TValue : notnull
 }
 public static class ResultBox
 {
+    public static ResultBox<UnitValue> Start => ResultBox.Ok(UnitValue.None);
+    
     public static ResultBox<TValue> FromValue<TValue>(TValue value) where TValue : notnull =>
         new(value, null);
     public static ResultBox<TValue> Ok<TValue>(TValue value) where TValue : notnull =>

--- a/src/ResultBoxes/ResultBoxes/UnitValue.cs
+++ b/src/ResultBoxes/ResultBoxes/UnitValue.cs
@@ -3,6 +3,7 @@ namespace ResultBoxes;
 public record UnitValue
 {
     public static UnitValue None => new();
+    public static UnitValue Unit => new();
     public static ResultBox<UnitValue> WrapTry(Action action)
         => ResultBox<UnitValue>.WrapTry(action);
     public static async Task<ResultBox<UnitValue>> WrapTry(Func<Task> action)


### PR DESCRIPTION
This pull request adds the `ResultBoxStartSpec` test class, which includes tests for using the `ResultBox.Start` property. The `ResultBox.Start` property returns a `ResultBox<UnitValue>` that represents a successful result. The tests ensure that the `ResultBox.Start` property returns a successful result and that the value can be accessed correctly.