### PR TITLE
feat: Add Error and FromException methods to ResultBox

### DIFF
--- a/src/ResultBoxes/ResultBoxes.Test/RescueSpec.cs
+++ b/src/ResultBoxes/ResultBoxes.Test/RescueSpec.cs
@@ -1,0 +1,79 @@
+using System.Net.Mime;
+namespace ResultBoxes.Test;
+
+public class RescueSpec
+{
+    [Fact]
+    public void RescueTest1()
+    {
+        var result = ResultBox.FromValue(1)
+            .Verify(_ =>new InvalidDataException("Invalid data"))
+            .Rescue(ex => ex is ArgumentNullException ? 2 : ValueOrException.Exception);
+        
+        Assert.False(result.IsSuccess);
+        Assert.IsType<InvalidDataException>( result.GetException());
+    }
+    [Fact]
+    public void RescueTest2()
+    {
+        var result = ResultBox.FromValue(1)
+            .Verify(_ =>new InvalidDataException("Invalid data"))
+            .Rescue(ex => ex is InvalidDataException ? 2 : ValueOrException.Exception);
+        
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.GetValue());
+    }
+    [Fact]
+    public void RescueTest3()
+    {
+        var result = ResultBox.FromValue(1)
+            .Verify(_ =>new InvalidDataException("Invalid data"))
+            .Rescue(ex => ex is ArgumentNullException ? 2 : ValueOrException<int>.Exception);
+        
+        Assert.False(result.IsSuccess);
+        Assert.IsType<InvalidDataException>( result.GetException());
+    }
+    [Fact]
+    public void RescueTest4()
+    {
+        var result = ResultBox.FromValue(1)
+            .Verify(_ =>new InvalidDataException("Invalid data"))
+            .Rescue(ex => ex is InvalidDataException ? ValueOrException<int>.FromValue(2) : ValueOrException.Exception);
+        
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.GetValue());
+    }
+    [Fact]
+    public void RescueTest5()
+    {
+        var result = ResultBox.FromValue(1)
+            .Verify(_ =>new InvalidDataException("Invalid data"))
+            .Rescue(ex => ex is InvalidDataException ? ValueOrException.FromValue(2) : ValueOrException.Exception);
+        
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.GetValue());
+    }
+    
+    
+    [Fact]
+    public async Task RescueTest1Async()
+    {
+        var result = await ResultBox.FromValue(Task.FromResult(1))
+            .Verify(_ =>new InvalidDataException("Invalid data"))
+            .Rescue(ex => ex is ArgumentNullException ? 2 : ValueOrException.Exception);
+        
+        Assert.False(result.IsSuccess);
+        Assert.IsType<InvalidDataException>( result.GetException());
+    }
+    [Fact]
+    public async Task RescueTest2Async()
+    {
+        var result = await ResultBox.FromValue(Task.FromResult(1))
+            .Verify(_ =>new InvalidDataException("Invalid data"))
+            .Rescue(ex => ex is InvalidDataException ? 2 : ValueOrException.Exception);
+        
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.GetValue());
+    }
+
+}

--- a/src/ResultBoxes/ResultBoxes/RemapExceptionExtensions.cs
+++ b/src/ResultBoxes/ResultBoxes/RemapExceptionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 namespace ResultBoxes;
 
 public static class RemapExceptionExtensions
@@ -46,4 +47,9 @@ public static class RemapExceptionExtensions
                 { IsSuccess: true } errorBox => ResultBox.FromValue(errorBox.GetValue()) 
             };
 
+}
+public record ValueOrException
+{
+    public static ValueOrException Exception = new();
+    public static ValueOrException<TValue> FromValue<TValue>(TValue value) where TValue : notnull => ValueOrException<TValue>.FromValue(value);
 }

--- a/src/ResultBoxes/ResultBoxes/RescueExtensions.cs
+++ b/src/ResultBoxes/ResultBoxes/RescueExtensions.cs
@@ -1,0 +1,63 @@
+namespace ResultBoxes;
+
+public static class RescueExtensions
+{
+    public static ResultBox<TValue> Rescue<TValue>(
+        this ResultBox<TValue> current,
+        Func<Exception, ValueOrException<TValue>> remapExceptionFunc)
+        where TValue : notnull
+        =>
+            current switch
+            {
+                { IsSuccess: false } => remapExceptionFunc(current.GetException()) switch
+                {
+                    { IsException: true } => ResultBox<TValue>.FromException(current.GetException()),
+                    { IsException: false } value => ResultBox.FromValue(value.GetValue())
+                },
+                { IsSuccess: true } => current.GetValue()
+            };
+    public static async Task<ResultBox<TValue>> Rescue<TValue>(
+        this ResultBox<TValue> current,
+        Func<Exception, Task<ValueOrException<TValue>>> remapExceptionFunc)
+        where TValue : notnull
+        =>
+            current switch
+            {
+                { IsSuccess: false } => await remapExceptionFunc(current.GetException()) switch
+                {
+                    { IsException: true } => ResultBox<TValue>.FromException(current.GetException()),
+                    { IsException: false } value => ResultBox.FromValue(value.GetValue())
+                },
+                { IsSuccess: true } => current.GetValue()
+            };
+
+    public static async Task<ResultBox<TValue>> Rescue<TValue>(
+        this Task<ResultBox<TValue>> current,
+        Func<Exception, ValueOrException<TValue>> remapExceptionFunc)
+        where TValue : notnull
+        =>
+            await current switch
+            {
+                { IsSuccess: false } errorBox => remapExceptionFunc(errorBox.GetException()) switch
+                {
+                    { IsException: true } => ResultBox<TValue>.FromException(errorBox.GetException()),
+                    { IsException: false } value => ResultBox.FromValue(value.GetValue())
+                },
+                { IsSuccess: true } valueBox => valueBox.GetValue()
+            };
+    public static async Task<ResultBox<TValue>> Rescue<TValue>(
+        this Task<ResultBox<TValue>> current,
+        Func<Exception, Task<ValueOrException<TValue>>> remapExceptionFunc)
+        where TValue : notnull
+        =>
+            await current switch
+            {
+                { IsSuccess: false } errorBox => await remapExceptionFunc(errorBox.GetException()) switch
+                {
+                    { IsException: true } => ResultBox<TValue>.FromException(errorBox.GetException()),
+                    { IsException: false } value => ResultBox.FromValue(value.GetValue())
+                },
+                { IsSuccess: true } valueBox => valueBox.GetValue()
+            };
+
+}

--- a/src/ResultBoxes/ResultBoxes/ResultBox.cs
+++ b/src/ResultBoxes/ResultBoxes/ResultBox.cs
@@ -112,6 +112,10 @@ public static class ResultBox
         new(await value(), null);
     public static ResultBox<UnitValue> Error(Exception exception) =>
         new(default, exception);
+    public static ResultBox<TValue> Error<TValue>(Exception exception) where TValue : notnull =>
+        new(default, exception);
+    public static ResultBox<TValue> FromException<TValue>(Exception exception) where TValue : notnull =>
+        new(default, exception);
 
     public static Task<ResultBox<TValueResult>> WrapTry<TValueResult>(Func<Task<TValueResult>> func)
         where TValueResult : notnull

--- a/src/ResultBoxes/ResultBoxes/ValueOrException.cs
+++ b/src/ResultBoxes/ResultBoxes/ValueOrException.cs
@@ -1,0 +1,11 @@
+namespace ResultBoxes;
+
+public record ValueOrException<TValue>(TValue? Value, bool IsException) where TValue : notnull
+{
+    public static ValueOrException<TValue> FromValue(TValue value) => new(value, false); 
+    public static ValueOrException<TValue> Exception => new(default, true);
+    public TValue GetValue() => (IsException == false ? Value : throw new ResultsInvalidOperationException() ) ?? throw new ResultsInvalidOperationException();
+    public static implicit operator ValueOrException<TValue>(TValue value) => FromValue(value);
+    public static implicit operator ValueOrException<TValue>(ValueOrException exception) => new(default, true);
+
+}


### PR DESCRIPTION
This commit adds the `Error` and `FromException` methods to the `ResultBox` class in the `ResultBoxes` project. The `Error` method allows creating a `ResultBox` with an exception, while the `FromException` method creates a `ResultBox` from an exception. These methods provide more flexibility in handling exceptions within the `ResultBox` class.