### PR TITLE
Add ConveyorWithRetrySpec  and test class

### DIFF
--- a/src/ResultBoxes/ResultBoxes.Test/ConveyorWithRetrySpec.cs
+++ b/src/ResultBoxes/ResultBoxes.Test/ConveyorWithRetrySpec.cs
@@ -1,0 +1,50 @@
+using Xunit.Abstractions;
+namespace ResultBoxes.Test;
+
+public class ConveyorWithRetrySpec(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    public async Task ConveyorWithRetryTest1()
+    {
+        var result = await ResultBox.FromValue(1)
+            .ConveyorWithRetry(async i =>
+            {
+                await Task.CompletedTask;
+                testOutputHelper.WriteLine($"{i} can not use");
+                return new ApplicationException($"can not use {i}");
+            }, new RetryPolicy(3, TimeSpan.Zero));
+        
+        Assert.False(result.IsSuccess); 
+    }
+    [Fact]
+    public async Task ConveyorWithRetryTest2()
+    {
+        var result = await ResultBox.FromValue(1)
+            .ConveyorWithRetry(async i =>
+            {
+                await Task.CompletedTask;
+                testOutputHelper.WriteLine($"{i} can not use");
+                return new ApplicationException($"can not use {i}");
+            }, new RetryPolicy(3, TimeSpan.FromSeconds(1)));
+        
+        Assert.False(result.IsSuccess); 
+    }
+
+    [Fact]
+    public async Task ConveyorWithRetryTest3()
+    {
+        var localCount = 0;
+        var result = await ResultBox.FromValue(1)
+            .ConveyorWithRetry(async i =>
+            {
+                localCount++;
+                await Task.CompletedTask;
+                testOutputHelper.WriteLine($"{i} can not use");
+                return localCount < 2 ? new ApplicationException($"can not use {i}, {localCount}") : localCount;
+            }, new RetryPolicy(5, TimeSpan.FromMilliseconds(100)));
+        
+        Assert.True(result.IsSuccess); 
+        Assert.Equal(2, result.GetValue()); 
+    }
+
+}

--- a/src/ResultBoxes/ResultBoxes/RemapExceptionExtensions.cs
+++ b/src/ResultBoxes/ResultBoxes/RemapExceptionExtensions.cs
@@ -50,6 +50,6 @@ public static class RemapExceptionExtensions
 }
 public record ValueOrException
 {
-    public static ValueOrException Exception = new();
+    public static readonly ValueOrException Exception = new();
     public static ValueOrException<TValue> FromValue<TValue>(TValue value) where TValue : notnull => ValueOrException<TValue>.FromValue(value);
 }

--- a/src/ResultBoxes/ResultBoxes/RemapExtensions.cs
+++ b/src/ResultBoxes/ResultBoxes/RemapExtensions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 namespace ResultBoxes;
 
 public static class RemapExtensions
@@ -150,4 +151,85 @@ public static class RemapExtensions
             { IsSuccess: true } => await current.GetValue().Call(valueFunc),
             _ => new ResultValueNullException()
         };
+}
+public interface IRetryPolicy
+{
+    public Task<ResultBox<bool>> ShouldRetryWithDelay(Exception exception, int exceptionCount);
+    public Func<Exception, Exception> RemapLastException { get; }
+}
+public record RetryPolicy(int MaxRetries, TimeSpan Delay) : IRetryPolicy
+{
+    protected readonly List<Exception> exceptions  = new();
+    public ImmutableList<Exception> Exceptions => exceptions.ToImmutableList();
+    public Task<ResultBox<bool>> ShouldRetryWithDelay(Exception exception, int exceptionCount) =>
+        exceptionCount < MaxRetries
+            ? ResultBox.Start.Scan(_ => Delay == TimeSpan.Zero ? Task.CompletedTask : Task.Delay(Delay))
+                .Scan(_ => exceptions.Add(exception))
+                .Remap(_ => Task.FromResult(true))
+            : ResultBox.Start
+                .Scan(_ => exceptions.Add(exception))
+                .Remap(_ => Task.FromResult(false));
+    public Func<Exception, Exception> RemapLastException { get; init; } = ex => ex;
+}
+
+public static class ConveyorWithRetryExtensions
+{
+    public static async Task<ResultBox<TValue>> ConveyorWithRetry<TValue>(
+        this ResultBox<TValue> current,
+        Func<TValue, Task<ResultBox<TValue>>> conveyorFunc,
+        IRetryPolicy retryPolicy)
+        where TValue : notnull
+        => await current.Conveyor(
+            async value => await Retry(value, conveyorFunc, retryPolicy));
+    public static async Task<ResultBox<TValue>> ConveyorWithRetry<TValue>(
+        this ResultBox<TValue> current,
+        Func<TValue, ResultBox<TValue>> conveyorFunc,
+        IRetryPolicy retryPolicy)
+        where TValue : notnull
+        => await current.Conveyor(async value => await Retry(value, conveyorFunc, retryPolicy));
+    public static async Task<ResultBox<TValue>> ConveyorWithRetry<TValue>(
+        this Task<ResultBox<TValue>> current,
+        Func<TValue, Task<ResultBox<TValue>>> conveyorFunc,
+        IRetryPolicy retryPolicy)
+        where TValue : notnull
+        => await current.Conveyor(async value => await Retry(value, conveyorFunc, retryPolicy));
+
+    public static async Task<ResultBox<TValue>> ConveyorWithRetry<TValue>(
+        this Task<ResultBox<TValue>> current,
+        Func<TValue, ResultBox<TValue>> conveyorFunc,
+        IRetryPolicy retryPolicy)
+        where TValue : notnull
+        => await current.Conveyor(async value => await Retry(value, conveyorFunc, retryPolicy));
+
+    #region private methods 
+    private static async Task<ResultBox<TValue>> Retry<TValue>(
+        TValue value,
+        Func<TValue, Task<ResultBox<TValue>>> conveyorFunc, IRetryPolicy retryPolicy)
+        where TValue : notnull
+    {
+        var exceptionCount = 0;
+        while (true)
+        {
+            var result = await conveyorFunc(value);
+            if (result.IsSuccess)
+            {
+                return result;
+            }
+            exceptionCount++;
+            var shouldRetry = await retryPolicy.ShouldRetryWithDelay(
+                result.GetException(),
+                exceptionCount);
+            if (!shouldRetry.IsSuccess || !shouldRetry.GetValue())
+            {
+                return result.RemapException(retryPolicy.RemapLastException);
+            }
+        }
+    }
+    private static async Task<ResultBox<TValue>> Retry<TValue>(
+        TValue value,
+        Func<TValue, ResultBox<TValue>> conveyorFunc, IRetryPolicy retryPolicy)
+        where TValue : notnull
+        => await Retry(value, async v => await Task.FromResult(conveyorFunc(v)), retryPolicy);
+    #endregion
+    
 }

--- a/src/ResultBoxes/ResultBoxes/RemapExtensions.cs
+++ b/src/ResultBoxes/ResultBoxes/RemapExtensions.cs
@@ -176,35 +176,36 @@ public static class ConveyorWithRetryExtensions
 {
     public static async Task<ResultBox<TValue>> ConveyorWithRetry<TValue>(
         this ResultBox<TValue> current,
-        Func<TValue, Task<ResultBox<TValue>>> conveyorFunc,
-        IRetryPolicy retryPolicy)
+        IRetryPolicy retryPolicy,
+        Func<TValue, Task<ResultBox<TValue>>> conveyorFunc)
         where TValue : notnull
         => await current.Conveyor(
-            async value => await Retry(value, conveyorFunc, retryPolicy));
+            async value => await Retry(value,retryPolicy, conveyorFunc));
     public static async Task<ResultBox<TValue>> ConveyorWithRetry<TValue>(
         this ResultBox<TValue> current,
-        Func<TValue, ResultBox<TValue>> conveyorFunc,
-        IRetryPolicy retryPolicy)
+        IRetryPolicy retryPolicy,
+        Func<TValue, ResultBox<TValue>> conveyorFunc)
         where TValue : notnull
-        => await current.Conveyor(async value => await Retry(value, conveyorFunc, retryPolicy));
+        => await current.Conveyor(async value => await Retry(value, retryPolicy, conveyorFunc));
     public static async Task<ResultBox<TValue>> ConveyorWithRetry<TValue>(
         this Task<ResultBox<TValue>> current,
         Func<TValue, Task<ResultBox<TValue>>> conveyorFunc,
         IRetryPolicy retryPolicy)
         where TValue : notnull
-        => await current.Conveyor(async value => await Retry(value, conveyorFunc, retryPolicy));
+        => await current.Conveyor(async value => await Retry(value,retryPolicy, conveyorFunc));
 
     public static async Task<ResultBox<TValue>> ConveyorWithRetry<TValue>(
         this Task<ResultBox<TValue>> current,
-        Func<TValue, ResultBox<TValue>> conveyorFunc,
-        IRetryPolicy retryPolicy)
+        IRetryPolicy retryPolicy,
+        Func<TValue, ResultBox<TValue>> conveyorFunc)
         where TValue : notnull
-        => await current.Conveyor(async value => await Retry(value, conveyorFunc, retryPolicy));
+        => await current.Conveyor(async value => await Retry(value,retryPolicy, conveyorFunc));
 
     #region private methods 
     private static async Task<ResultBox<TValue>> Retry<TValue>(
         TValue value,
-        Func<TValue, Task<ResultBox<TValue>>> conveyorFunc, IRetryPolicy retryPolicy)
+        IRetryPolicy retryPolicy,
+        Func<TValue, Task<ResultBox<TValue>>> conveyorFunc)
         where TValue : notnull
     {
         var exceptionCount = 0;
@@ -227,9 +228,10 @@ public static class ConveyorWithRetryExtensions
     }
     private static async Task<ResultBox<TValue>> Retry<TValue>(
         TValue value,
-        Func<TValue, ResultBox<TValue>> conveyorFunc, IRetryPolicy retryPolicy)
+        IRetryPolicy retryPolicy,
+        Func<TValue, ResultBox<TValue>> conveyorFunc)
         where TValue : notnull
-        => await Retry(value, async v => await Task.FromResult(conveyorFunc(v)), retryPolicy);
+        => await Retry(value,retryPolicy, async v => await Task.FromResult(conveyorFunc(v)));
     #endregion
     
 }

--- a/src/ResultBoxes/ResultBoxes/ResultBoxes.csproj
+++ b/src/ResultBoxes/ResultBoxes/ResultBoxes.csproj
@@ -7,12 +7,12 @@
         <RootNamespace>ResultBoxes</RootNamespace>
         <LangVersion>preview</LangVersion>
         <PackageId>ResultBoxes</PackageId>
-        <Version>0.3.8</Version>
+        <Version>0.3.9</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>ResultBoxes - C# Results Library that focus on Railway Programming.</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/ResultBoxes</RepositoryUrl>
-        <PackageVersion>0.3.8</PackageVersion>
+        <PackageVersion>0.3.9</PackageVersion>
         <Description>Add ResultBox.FromValue()</Description>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
This commit adds the ConveyorWithRetrySpec test class and the ConveyorWithRetryExtensions class to the ResultBoxes project. The ConveyorWithRetrySpec class contains unit tests for the ConveyorWithRetry method, while the ConveyorWithRetryExtensions class provides extension methods for retrying conveyor functions in ResultBox objects.