### PR TITLE
Add CheckNull method overloads for nullable value types

### DIFF
--- a/src/ResultBoxes/ResultBoxes.Test/CheckNullSpec.cs
+++ b/src/ResultBoxes/ResultBoxes.Test/CheckNullSpec.cs
@@ -9,6 +9,37 @@ public class CheckNullSpec
         
         Assert.True(result.IsSuccess);
     }
+
+    private Guid? TestGuid(int value) => value == 0 ? null : Guid.NewGuid();
+    private int? TestInt(int value) => value == 0 ? null : value;
+
+
+    [Fact]
+    public void CheckNullTestWithPrimitive()
+    {
+        var result = ResultBox.CheckNull(TestGuid(0));
+        Assert.False(result.IsSuccess);
+    }
+    [Fact]
+    public void CheckNullTestWithPrimitive2()
+    {
+        var result = ResultBox.CheckNull(TestGuid(1));
+        Assert.True(result.IsSuccess);
+    }
+    [Fact]
+    public void CheckNullTestWithPrimitiveInt()
+    {
+        var result = ResultBox.CheckNull(TestInt(0));
+        Assert.False(result.IsSuccess);
+    }
+    [Fact]
+    public void CheckNullTestWithPrimitiveInt2()
+    {
+        var result = ResultBox.CheckNull(TestInt(1));
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, result.GetValue());
+    }
+    
     [Fact]
     public void CheckNullTest2()
     {

--- a/src/ResultBoxes/ResultBoxes/ResultBox.cs
+++ b/src/ResultBoxes/ResultBoxes/ResultBox.cs
@@ -151,6 +151,29 @@ public static class ResultBox
         _ => ResultBox<TValue>.FromException(
             exception ?? new ResultValueNullException(typeof(TValue).Name))
     };
+    public static ResultBox<TValue> CheckNull<TValue>(TValue? value, Exception? exception = null)
+        where TValue : struct => value switch
+    {
+        { } v => ResultBox.FromValue(v),
+        _ => ResultBox<TValue>.FromException(
+            exception ?? new ResultValueNullException(typeof(TValue).Name))
+    };
+
+    public static async Task<ResultBox<TValue>> CheckNull<TValue>(Task<TValue?> value, Exception? exception = null)
+        where TValue : notnull => await value switch
+    {
+        { } v => ResultBox.FromValue(v),
+        _ => ResultBox<TValue>.FromException(
+            exception ?? new ResultValueNullException(typeof(TValue).Name))
+    };
+    public static async Task<ResultBox<TValue>> CheckNull<TValue>(Task<TValue?> value, Exception? exception = null)
+        where TValue : struct => await value switch
+    {
+        { } v => ResultBox.FromValue(v),
+        _ => ResultBox<TValue>.FromException(
+            exception ?? new ResultValueNullException(typeof(TValue).Name))
+    };
+    
     public static ResultBox<TValue> CheckNull<TValue>(Func<TValue?> valueFunc, Exception? exception = null)
         where TValue : notnull => valueFunc() switch
     {
@@ -158,6 +181,14 @@ public static class ResultBox
         _ => ResultBox<TValue>.FromException(
             exception ?? new ResultValueNullException(typeof(TValue).Name))
     };
+    public static ResultBox<TValue> CheckNull<TValue>(Func<TValue?> valueFunc, Exception? exception = null)
+        where TValue : struct => valueFunc() switch
+    {
+        { } value => ResultBox.FromValue(value),
+        _ => ResultBox<TValue>.FromException(
+            exception ?? new ResultValueNullException(typeof(TValue).Name))
+    };
+    
     public static async Task<ResultBox<TValue>> CheckNull<TValue>(Func<Task<TValue?>> valueFunc, Exception? exception = null)
         where TValue : notnull => await valueFunc() switch
     {
@@ -165,6 +196,14 @@ public static class ResultBox
         _ => ResultBox<TValue>.FromException(
             exception ?? new ResultValueNullException(typeof(TValue).Name))
     };
+    public static async Task<ResultBox<TValue>> CheckNull<TValue>(Func<Task<TValue?>> valueFunc, Exception? exception = null)
+        where TValue : struct => await valueFunc() switch
+    {
+        { } value => ResultBox.FromValue(value),
+        _ => ResultBox<TValue>.FromException(
+            exception ?? new ResultValueNullException(typeof(TValue).Name))
+    };
+    
     public static ResultBox<TValue> CheckNullWrapTry<TValue>(Func<TValue?> func, Func<Exception, Exception>? exceptionMapper = null)
         where TValue : notnull
     {
@@ -183,8 +222,45 @@ public static class ResultBox
             return exceptionMapper?.Invoke(e) ?? e;
         }
     }
+    public static ResultBox<TValue> CheckNullWrapTry<TValue>(Func<TValue?> func, Func<Exception, Exception>? exceptionMapper = null)
+        where TValue : struct
+    {
+        try
+        {
+            var result = func();
+            return result.HasValue switch
+            {
+                true => ResultBox<TValue>.FromValue(result.Value),
+                _ => ResultBox<TValue>.FromException(
+                    new ResultValueNullException(typeof(TValue).Name)
+                )
+            };
+        }
+        catch (Exception e)
+        {
+            return exceptionMapper?.Invoke(e) ?? e;
+        }
+    }
     public static async Task<ResultBox<TValue>> CheckNullWrapTry<TValue>(Func<Task<TValue?>> funcAsync, Func<Exception, Exception>? exceptionMapper = null)
         where TValue : notnull
+    {
+        try
+        {
+            return await funcAsync() switch
+            {
+                { } value => ResultBox.FromValue(value),
+                _ => ResultBox<TValue>.FromException(
+                    new ResultValueNullException(typeof(TValue).Name)
+                )
+            };
+        }
+        catch (Exception e)
+        {
+            return exceptionMapper?.Invoke(e) ?? e;
+        }
+    }
+    public static async Task<ResultBox<TValue>> CheckNullWrapTry<TValue>(Func<Task<TValue?>> funcAsync, Func<Exception, Exception>? exceptionMapper = null)
+        where TValue : struct
     {
         try
         {

--- a/src/ResultBoxes/ResultBoxes/ResultBoxes.csproj
+++ b/src/ResultBoxes/ResultBoxes/ResultBoxes.csproj
@@ -7,13 +7,13 @@
         <RootNamespace>ResultBoxes</RootNamespace>
         <LangVersion>preview</LangVersion>
         <PackageId>ResultBoxes</PackageId>
-        <Version>0.3.19</Version>
+        <Version>0.3.20</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>ResultBoxes - C# Results Library that focus on Railway Programming.</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/ResultBoxes</RepositoryUrl>
-        <PackageVersion>0.3.19</PackageVersion>
-        <Description>Conveyer, Verify can take no param. Verify can take Task and Result</Description>
+        <PackageVersion>0.3.20</PackageVersion>
+        <Description>Guid? int? can use CheckNull, CheckNullWrapTry as well</Description>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
This pull request adds new method overloads for the `CheckNull` method that can handle nullable value types. It includes changes to the code and the package version.