### PR TITLE
Bump version to 0.3.30 and add Cast extensions with unit tests

### DIFF
--- a/src/ResultBoxes/ResultBoxes.Test/CastSpec.cs
+++ b/src/ResultBoxes/ResultBoxes.Test/CastSpec.cs
@@ -1,0 +1,41 @@
+namespace ResultBoxes.Test;
+
+public class CastSpec
+{
+    [Fact]
+    public async Task TestCode()
+    {
+        await Task.CompletedTask;
+        var castedResultBox = ResultBox<ITest>.FromValue(new Test()).Cast<ITest, Test>();
+        Assert.IsType<ResultBox<Test>>(castedResultBox);
+
+        var resultBoxTask = Task.FromResult(ResultBox<ITest>.FromValue(new Test()));
+        var castedResultBox2 = await resultBoxTask.Cast<ITest, Test>();
+        var castedResultBoxTask = resultBoxTask.Cast<ITest, Test>();
+        Assert.IsType<ResultBox<Test>>(castedResultBox2);
+        await Assert.IsType<Task<ResultBox<Test>>>(castedResultBoxTask);
+    }
+    [Fact]
+    public async Task TestCode2()
+    {
+        await Task.CompletedTask;
+        var resultBox = ResultBox<ITest>.FromValue(new Test());
+        var castedResultBox = resultBox.Cast<Test>();
+        Assert.IsType<ResultBox<Test>>(castedResultBox);
+
+        var resultBoxTask = Task.FromResult(resultBox).Conveyor(val => val.ToResultBox().Cast<Test>());
+        await Assert.IsType<Task<ResultBox<Test>>>(resultBoxTask);
+
+        var resultBoxTask2 = Task.FromResult(resultBox).ConveyorResult(result => result.Cast<Test>());
+        await Assert.IsType<Task<ResultBox<Test>>>(resultBoxTask2);
+
+        var resultBoxTask3 = Task.FromResult(resultBox).ConveyorResult(ResultBox.Cast<ITest, Test>);
+        await Assert.IsType<Task<ResultBox<Test>>>(resultBoxTask2);
+    }
+    public interface ITest
+    {
+    }
+    public record Test : ITest
+    {
+    }
+}

--- a/src/ResultBoxes/ResultBoxes/CastExtensions.cs
+++ b/src/ResultBoxes/ResultBoxes/CastExtensions.cs
@@ -1,0 +1,28 @@
+namespace ResultBoxes;
+
+public static class CastExtensions
+{
+    public static ResultBox<TCasted> Cast<TOriginal, TCasted>(this ResultBox<TOriginal> resultBox)
+        where TCasted : notnull where TOriginal : notnull
+    {
+        if (resultBox.IsSuccess)
+        {
+            return resultBox.GetValue() is TCasted castedValue
+                ? ResultBox<TCasted>.FromValue(castedValue)
+                : ResultBox<TCasted>.Error(new InvalidCastException($"Cannot cast value to {typeof(TCasted).Name}"));
+        }
+        return ResultBox<TCasted>.FromException(resultBox.GetException());
+    }
+    public static async Task<ResultBox<TCasted>> Cast<TOriginal, TCasted>(this Task<ResultBox<TOriginal>> resultBoxTask)
+        where TCasted : notnull where TOriginal : notnull
+    {
+        var resultBox = await resultBoxTask;
+        if (resultBox.IsSuccess)
+        {
+            return resultBox.GetValue() is TCasted castedValue
+                ? ResultBox<TCasted>.FromValue(castedValue)
+                : ResultBox<TCasted>.Error(new InvalidCastException($"Cannot cast value to {typeof(TCasted).Name}"));
+        }
+        return ResultBox<TCasted>.FromException(resultBox.GetException());
+    }
+}

--- a/src/ResultBoxes/ResultBoxes/ResultBox.cs
+++ b/src/ResultBoxes/ResultBoxes/ResultBox.cs
@@ -1,21 +1,21 @@
 using System.Text.Json.Serialization;
-
 namespace ResultBoxes;
 
 public record ResultBox<TValue> where TValue : notnull
 {
     private readonly Exception? exception;
 
-    internal ResultBox(TValue? value, Exception? exception) =>
-        (Value, this.exception) = (value, exception);
-
-    [JsonIgnore] public bool IsSuccess => Exception is null && Value is not null;
+    [JsonIgnore]
+    public bool IsSuccess => Exception is null && Value is not null;
 
     public static ResultBox<TValue> OutOfRange => new(new ResultValueNullException());
     internal TValue? Value { get; }
 
     public Exception? Exception =>
         exception ?? (Value is null ? new ResultValueNullException() : null);
+
+    internal ResultBox(TValue? value, Exception? exception) =>
+        (Value, this.exception) = (value, exception);
 
     public Exception GetException() =>
         Exception ?? throw new ResultsInvalidOperationException("no exception");
@@ -40,14 +40,20 @@ public record ResultBox<TValue> where TValue : notnull
     public static ResultBox<TValue> Error(Exception exception) =>
         new(default, exception);
 
+    public ResultBox<TCasted> Cast<TCasted>() where TCasted : notnull =>
+        this switch
+        {
+            { IsSuccess: false } => GetException(),
+            { IsSuccess: true } => new ResultBox<TCasted>((TCasted)(object)GetValue(), null),
+            _ => new ResultValueNullException()
+        };
 
     public static implicit operator ResultBox<TValue>(TValue value) => new(value, null);
 
     public static implicit operator ResultBox<TValue>(Exception exception) =>
         new(default, exception);
 
-    public ResultBox<TwoValues<TValue, TValue2>> Append<TValue2>(TValue2 value2)
-        where TValue2 : notnull =>
+    public ResultBox<TwoValues<TValue, TValue2>> Append<TValue2>(TValue2 value2) where TValue2 : notnull =>
         this switch
         {
             { IsSuccess: false } => GetException(),
@@ -95,7 +101,8 @@ public record ResultBox<TValue> where TValue : notnull
         }
     }
 
-    public static async Task<ResultBox<TValue>> WrapTry(Func<Task<TValue>> func,
+    public static async Task<ResultBox<TValue>> WrapTry(
+        Func<Task<TValue>> func,
         Func<Exception, Exception>? exceptionMapper)
     {
         try
@@ -108,7 +115,6 @@ public record ResultBox<TValue> where TValue : notnull
         }
     }
 }
-
 public static class ResultBox
 {
     public static ResultBox<UnitValue> Start => Ok(ResultBoxes.UnitValue.None);
@@ -120,12 +126,10 @@ public static class ResultBox
     public static ResultBox<TValue> Ok<TValue>(TValue value) where TValue : notnull =>
         new(value, null);
 
-    public static async Task<ResultBox<TValue>> FromValue<TValue>(Task<TValue> value)
-        where TValue : notnull =>
+    public static async Task<ResultBox<TValue>> FromValue<TValue>(Task<TValue> value) where TValue : notnull =>
         new(await value, null);
 
-    public static async Task<ResultBox<TValue>> FromValue<TValue>(Func<Task<TValue>> value)
-        where TValue : notnull =>
+    public static async Task<ResultBox<TValue>> FromValue<TValue>(Func<Task<TValue>> value) where TValue : notnull =>
         new(await value(), null);
 
     public static ResultBox<UnitValue> Error(Exception exception) =>
@@ -136,24 +140,23 @@ public static class ResultBox
 
     public static ResultBox<TValue> FromException<TValue>(Exception exception) where TValue : notnull =>
         new(default, exception);
-    public static async Task<ResultBox<TValue>> FromException<TValue>(Task<Exception> exception) where TValue : notnull =>
+    public static async Task<ResultBox<TValue>> FromException<TValue>(Task<Exception> exception)
+        where TValue : notnull =>
         new(default, await exception);
 
-    public static Task<ResultBox<TValueResult>> WrapTry<TValueResult>(Func<Task<TValueResult>> func,
-        Func<Exception, Exception>? exceptionMapper = null)
-        where TValueResult : notnull
-        => ResultBox<TValueResult>.WrapTry(func, exceptionMapper);
+    public static Task<ResultBox<TValueResult>> WrapTry<TValueResult>(
+        Func<Task<TValueResult>> func,
+        Func<Exception, Exception>? exceptionMapper = null) where TValueResult : notnull =>
+        ResultBox<TValueResult>.WrapTry(func, exceptionMapper);
 
-    public static ResultBox<TValueResult> WrapTry<TValueResult>(Func<TValueResult> func,
-        Func<Exception, Exception>? exceptionMapper = null)
-        where TValueResult : notnull
-        => ResultBox<TValueResult>.WrapTry(func, exceptionMapper);
+    public static ResultBox<TValueResult> WrapTry<TValueResult>(
+        Func<TValueResult> func,
+        Func<Exception, Exception>? exceptionMapper = null) where TValueResult : notnull =>
+        ResultBox<TValueResult>.WrapTry(func, exceptionMapper);
 
-    public static void LogResult<TValue>(ResultBox<TValue> result) where TValue : notnull
-        => LogResult(result, "");
+    public static void LogResult<TValue>(ResultBox<TValue> result) where TValue : notnull => LogResult(result, "");
 
-    public static void LogResult<TValue>(ResultBox<TValue> result, string marking)
-        where TValue : notnull
+    public static void LogResult<TValue>(ResultBox<TValue> result, string marking) where TValue : notnull
     {
         switch (result)
         {
@@ -161,8 +164,7 @@ public static class ResultBox
                 Console.WriteLine(SpaceWithMarking(marking) + "Value: " + result.GetValue());
                 break;
             case { IsSuccess: false }:
-                Console.WriteLine(
-                    SpaceWithMarking(marking) + "Error: " + result.GetException().Message);
+                Console.WriteLine(SpaceWithMarking(marking) + "Error: " + result.GetException().Message);
                 break;
         }
     }
@@ -174,80 +176,72 @@ public static class ResultBox
         where TValue : notnull => value switch
     {
         not null => FromValue(value),
-        _ => ResultBox<TValue>.FromException(
-            exception ?? new ResultValueNullException(typeof(TValue).Name))
+        _ => ResultBox<TValue>.FromException(exception ?? new ResultValueNullException(typeof(TValue).Name))
     };
 
     public static ResultBox<TValue> CheckNull<TValue>(TValue? value, Exception? exception = null)
         where TValue : struct => value switch
     {
         { } v => FromValue(v),
-        _ => ResultBox<TValue>.FromException(
-            exception ?? new ResultValueNullException(typeof(TValue).Name))
+        _ => ResultBox<TValue>.FromException(exception ?? new ResultValueNullException(typeof(TValue).Name))
     };
 
     public static async Task<ResultBox<TValue>> CheckNull<TValue>(Task<TValue?> value, Exception? exception = null)
         where TValue : notnull => await value switch
     {
         { } v => FromValue(v),
-        _ => ResultBox<TValue>.FromException(
-            exception ?? new ResultValueNullException(typeof(TValue).Name))
+        _ => ResultBox<TValue>.FromException(exception ?? new ResultValueNullException(typeof(TValue).Name))
     };
 
     public static async Task<ResultBox<TValue>> CheckNull<TValue>(Task<TValue?> value, Exception? exception = null)
         where TValue : struct => await value switch
     {
         { } v => FromValue(v),
-        _ => ResultBox<TValue>.FromException(
-            exception ?? new ResultValueNullException(typeof(TValue).Name))
+        _ => ResultBox<TValue>.FromException(exception ?? new ResultValueNullException(typeof(TValue).Name))
     };
 
     public static ResultBox<TValue> CheckNull<TValue>(Func<TValue?> valueFunc, Exception? exception = null)
         where TValue : notnull => valueFunc() switch
     {
         { } value => FromValue(value),
-        _ => ResultBox<TValue>.FromException(
-            exception ?? new ResultValueNullException(typeof(TValue).Name))
+        _ => ResultBox<TValue>.FromException(exception ?? new ResultValueNullException(typeof(TValue).Name))
     };
 
     public static ResultBox<TValue> CheckNull<TValue>(Func<TValue?> valueFunc, Exception? exception = null)
         where TValue : struct => valueFunc() switch
     {
         { } value => FromValue(value),
-        _ => ResultBox<TValue>.FromException(
-            exception ?? new ResultValueNullException(typeof(TValue).Name))
+        _ => ResultBox<TValue>.FromException(exception ?? new ResultValueNullException(typeof(TValue).Name))
     };
 
-    public static async Task<ResultBox<TValue>> CheckNull<TValue>(Func<Task<TValue?>> valueFunc,
-        Exception? exception = null)
-        where TValue : notnull => await valueFunc() switch
+    public static async Task<ResultBox<TValue>> CheckNull<TValue>(
+        Func<Task<TValue?>> valueFunc,
+        Exception? exception = null) where TValue : notnull => await valueFunc() switch
     {
         { } value => FromValue(value),
-        _ => ResultBox<TValue>.FromException(
-            exception ?? new ResultValueNullException(typeof(TValue).Name))
+        _ => ResultBox<TValue>.FromException(exception ?? new ResultValueNullException(typeof(TValue).Name))
     };
 
-    public static async Task<ResultBox<TValue>> CheckNull<TValue>(Func<Task<TValue?>> valueFunc,
-        Exception? exception = null)
-        where TValue : struct => await valueFunc() switch
+    public static async Task<ResultBox<TValue>> CheckNull<TValue>(
+        Func<Task<TValue?>> valueFunc,
+        Exception? exception = null) where TValue : struct => await valueFunc() switch
     {
         { } value => FromValue(value),
-        _ => ResultBox<TValue>.FromException(
-            exception ?? new ResultValueNullException(typeof(TValue).Name))
+        _ => ResultBox<TValue>.FromException(exception ?? new ResultValueNullException(typeof(TValue).Name))
     };
 
-    public static ResultBox<TValue> CheckNullWrapTry<TValue>(Func<TValue?> func,
-        Func<Exception, Exception>? exceptionMapper = null)
-        where TValue : notnull
+    public static ResultBox<TValue> CheckNullWrapTry<TValue>(
+        Func<TValue?> func,
+        Func<Exception, Exception>? exceptionMapper = null) where TValue : notnull
     {
         try
         {
             return func() switch
             {
                 { } value => FromValue(value),
-                _ => ResultBox<TValue>.FromException(
-                    new ResultValueNullException(typeof(TValue).Name)
-                ).RemapException(e => exceptionMapper?.Invoke(e) ?? e)
+                _ => ResultBox<TValue>
+                    .FromException(new ResultValueNullException(typeof(TValue).Name))
+                    .RemapException(e => exceptionMapper?.Invoke(e) ?? e)
             };
         }
         catch (Exception e)
@@ -256,9 +250,9 @@ public static class ResultBox
         }
     }
 
-    public static ResultBox<TValue> CheckNullWrapTry<TValue>(Func<TValue?> func,
-        Func<Exception, Exception>? exceptionMapper = null)
-        where TValue : struct
+    public static ResultBox<TValue> CheckNullWrapTry<TValue>(
+        Func<TValue?> func,
+        Func<Exception, Exception>? exceptionMapper = null) where TValue : struct
     {
         try
         {
@@ -266,9 +260,9 @@ public static class ResultBox
             return result.HasValue switch
             {
                 true => ResultBox<TValue>.FromValue(result.Value),
-                _ => ResultBox<TValue>.FromException(
-                    new ResultValueNullException(typeof(TValue).Name)
-                ).RemapException(e => exceptionMapper?.Invoke(e) ?? e)
+                _ => ResultBox<TValue>
+                    .FromException(new ResultValueNullException(typeof(TValue).Name))
+                    .RemapException(e => exceptionMapper?.Invoke(e) ?? e)
             };
         }
         catch (Exception e)
@@ -277,18 +271,18 @@ public static class ResultBox
         }
     }
 
-    public static async Task<ResultBox<TValue>> CheckNullWrapTry<TValue>(Func<Task<TValue?>> funcAsync,
-        Func<Exception, Exception>? exceptionMapper = null)
-        where TValue : notnull
+    public static async Task<ResultBox<TValue>> CheckNullWrapTry<TValue>(
+        Func<Task<TValue?>> funcAsync,
+        Func<Exception, Exception>? exceptionMapper = null) where TValue : notnull
     {
         try
         {
             return await funcAsync() switch
             {
                 { } value => FromValue(value),
-                _ => ResultBox<TValue>.FromException(
-                    new ResultValueNullException(typeof(TValue).Name)
-                ).RemapException(e => exceptionMapper?.Invoke(e) ?? e)
+                _ => ResultBox<TValue>
+                    .FromException(new ResultValueNullException(typeof(TValue).Name))
+                    .RemapException(e => exceptionMapper?.Invoke(e) ?? e)
             };
         }
         catch (Exception e)
@@ -297,18 +291,18 @@ public static class ResultBox
         }
     }
 
-    public static async Task<ResultBox<TValue>> CheckNullWrapTry<TValue>(Func<Task<TValue?>> funcAsync,
-        Func<Exception, Exception>? exceptionMapper = null)
-        where TValue : struct
+    public static async Task<ResultBox<TValue>> CheckNullWrapTry<TValue>(
+        Func<Task<TValue?>> funcAsync,
+        Func<Exception, Exception>? exceptionMapper = null) where TValue : struct
     {
         try
         {
             return await funcAsync() switch
             {
                 { } value => FromValue(value),
-                _ => ResultBox<TValue>.FromException(
-                    new ResultValueNullException(typeof(TValue).Name)
-                ).RemapException(e => exceptionMapper?.Invoke(e) ?? e)
+                _ => ResultBox<TValue>
+                    .FromException(new ResultValueNullException(typeof(TValue).Name))
+                    .RemapException(e => exceptionMapper?.Invoke(e) ?? e)
             };
         }
         catch (Exception e)
@@ -317,16 +311,26 @@ public static class ResultBox
         }
     }
 
-    public static ResultBox<TValue> CheckOptionalEmpty<TValue>(OptionalValue<TValue> optionalValue,
-        Exception? exception)
-        where TValue : notnull
-        => optionalValue.HasValue switch
-        {
-            true => FromValue(optionalValue.GetValue()),
-            _ => ResultBox<TValue>.FromException(exception ?? new ResultValueNullException(typeof(TValue).Name))
-        };
+    public static ResultBox<TValue> CheckOptionalEmpty<TValue>(
+        OptionalValue<TValue> optionalValue,
+        Exception? exception) where TValue : notnull => optionalValue.HasValue switch
+    {
+        true => FromValue(optionalValue.GetValue()),
+        _ => ResultBox<TValue>.FromException(exception ?? new ResultValueNullException(typeof(TValue).Name))
+    };
 
     public static ResultBox<TValue> CheckOptionalEmpty<TValue>(OptionalValue<TValue> optionalValue)
-        where TValue : notnull
-        => CheckOptionalEmpty(optionalValue, null);
+        where TValue : notnull => CheckOptionalEmpty(optionalValue, null);
+
+    public static ResultBox<TCasted> Cast<TOriginal, TCasted>(ResultBox<TOriginal> resultBox)
+        where TCasted : notnull where TOriginal : notnull
+    {
+        if (resultBox.IsSuccess)
+        {
+            return resultBox.GetValue() is TCasted castedValue
+                ? ResultBox<TCasted>.FromValue(castedValue)
+                : ResultBox<TCasted>.Error(new InvalidCastException($"Cannot cast value to {typeof(TCasted).Name}"));
+        }
+        return ResultBox<TCasted>.FromException(resultBox.GetException());
+    }
 }

--- a/src/ResultBoxes/ResultBoxes/ResultBoxes.csproj
+++ b/src/ResultBoxes/ResultBoxes/ResultBoxes.csproj
@@ -6,12 +6,12 @@
         <RootNamespace>ResultBoxes</RootNamespace>
         <LangVersion>preview</LangVersion>
         <PackageId>ResultBoxes</PackageId>
-        <Version>0.3.29</Version>
+        <Version>0.3.30</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>ResultBoxes - C# Results Library that focus on Railway Programming.</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/ResultBoxes</RepositoryUrl>
-        <PackageVersion>0.3.29</PackageVersion>
+        <PackageVersion>0.3.30</PackageVersion>
         <Description>Fixed combine</Description>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
This pull request introduces a new casting feature to the `ResultBox` class and includes several refactorings for better readability and consistency. The primary changes involve adding new methods for casting `ResultBox` instances and updating existing methods to improve code quality.

New casting feature:

* [`src/ResultBoxes/ResultBoxes/CastExtensions.cs`](diffhunk://#diff-58ba0da23c16883073c7cd22ec6689f97383472732e032d1a75c420e230e04e6R1-R28): Introduced `Cast` extension methods to enable casting between different `ResultBox` types.
* [`src/ResultBoxes/ResultBoxes/ResultBox.cs`](diffhunk://#diff-daeda0196f199ce24b50a4311e65d1254c6057b7d597e98da0a8e2cd3c8137ceR43-R56): Added `Cast` method to the `ResultBox` class for casting between different `ResultBox` types. [[1]](diffhunk://#diff-daeda0196f199ce24b50a4311e65d1254c6057b7d597e98da0a8e2cd3c8137ceR43-R56) [[2]](diffhunk://#diff-daeda0196f199ce24b50a4311e65d1254c6057b7d597e98da0a8e2cd3c8137ceL320-R335)

Test cases:

* [`src/ResultBoxes/ResultBoxes.Test/CastSpec.cs`](diffhunk://#diff-a1b2dcc092950d464db0b74783e865cc86df7b8e2c800e3609a22363acd25c5bR1-R41): Added new test cases to verify the casting functionality of `ResultBox`.

Refactoring and code quality improvements:

* [`src/ResultBoxes/ResultBoxes/ResultBox.cs`](diffhunk://#diff-daeda0196f199ce24b50a4311e65d1254c6057b7d597e98da0a8e2cd3c8137ceL98-R105): Reformatted various methods for better readability and consistency, including `WrapTry`, `CheckNull`, and `CheckNullWrapTry`. [[1]](diffhunk://#diff-daeda0196f199ce24b50a4311e65d1254c6057b7d597e98da0a8e2cd3c8137ceL98-R105) [[2]](diffhunk://#diff-daeda0196f199ce24b50a4311e65d1254c6057b7d597e98da0a8e2cd3c8137ceL111) [[3]](diffhunk://#diff-daeda0196f199ce24b50a4311e65d1254c6057b7d597e98da0a8e2cd3c8137ceL139-R167) [[4]](diffhunk://#diff-daeda0196f199ce24b50a4311e65d1254c6057b7d597e98da0a8e2cd3c8137ceL177-R244) [[5]](diffhunk://#diff-daeda0196f199ce24b50a4311e65d1254c6057b7d597e98da0a8e2cd3c8137ceL259-R265) [[6]](diffhunk://#diff-daeda0196f199ce24b50a4311e65d1254c6057b7d597e98da0a8e2cd3c8137ceL280-R285) [[7]](diffhunk://#diff-daeda0196f199ce24b50a4311e65d1254c6057b7d597e98da0a8e2cd3c8137ceL300-R305)

Version update:

* [`src/ResultBoxes/ResultBoxes/ResultBoxes.csproj`](diffhunk://#diff-5bc0af3f831eb18185452901667b249e30a3742061110ca56a1bbc92a62ac435L9-R14): Updated the package version from `0.3.29` to `0.3.30`.