### PR TITLE
Add AOT compatibility, trimming support, and .NET 10 target

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -9,15 +9,14 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET 8
-      uses: actions/setup-dotnet@v1
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
-    - name: Setup .NET 9
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 9.0.x
+        dotnet-version: |
+          8.0.x
+          9.0.x
+          10.0.x
     - name: Restore dependencies
       run: |
         pushd ./src/ResultBoxes

--- a/src/ResultBoxes/ResultBoxes.Test/ResultBoxes.Test.csproj
+++ b/src/ResultBoxes/ResultBoxes.Test/ResultBoxes.Test.csproj
@@ -7,7 +7,7 @@
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
         <RootNamespace>ResultBoxes.Test</RootNamespace>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/ResultBoxes/ResultBoxes.Usage/ResultBoxes.Usage.csproj
+++ b/src/ResultBoxes/ResultBoxes.Usage/ResultBoxes.Usage.csproj
@@ -4,7 +4,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>SingleResults.Usage</RootNamespace>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <LangVersion>preview</LangVersion>
     </PropertyGroup>
 

--- a/src/ResultBoxes/ResultBoxes/ResultBoxes.csproj
+++ b/src/ResultBoxes/ResultBoxes/ResultBoxes.csproj
@@ -6,20 +6,22 @@
         <RootNamespace>ResultBoxes</RootNamespace>
         <LangVersion>preview</LangVersion>
         <PackageId>ResultBoxes</PackageId>
-        <Version>0.3.31</Version>
+        <Version>0.4.0</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>ResultBoxes - C# Results Library that focus on Railway Programming.</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/ResultBoxes</RepositoryUrl>
-        <PackageVersion>0.3.31</PackageVersion>
-        <Description>Fixed combine</Description>
+        <PackageVersion>0.4.0</PackageVersion>
+        <Description>Added AOT compatibility, trimming support, and .NET 10 target</Description>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <GenerateSBOM>true</GenerateSBOM>
+        <IsAotCompatible>true</IsAotCompatible>
+        <IsTrimmable>true</IsTrimmable>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Changes

- Add `IsAotCompatible` and `IsTrimmable` to ResultBoxes.csproj for AOT/WASM/NativeAOT support
- Add `net10.0` target to all projects (ResultBoxes, Test, Usage)
- Update GitHub Actions workflow:
  - Upgrade actions/checkout to v4
  - Upgrade actions/setup-dotnet to v4
  - Add .NET 10 SDK
- Bump version to 0.4.0

## Benefits

- Enables ResultBoxes to be used in WASM (Blazor WebAssembly) applications
- Enables ResultBoxes to be used in NativeAOT deployments
- Smaller deployment size due to trimming support
- Faster startup time in AOT scenarios

## Verification

- ✅ No AOT-incompatible patterns found in codebase
- ✅ Build succeeded for net8.0, net9.0, net10.0
- ✅ All 546 tests passed